### PR TITLE
JSON output format and --once output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ If you don't have the dependencies, you can use Docker for the build (will downl
 git clone https://github.com/ThomasBaruzier/gddr6-core-junction-vram-temps && cd gddr6-core-junction-vram-temps && ./build-docker.sh && sudo ./gputemps
 ```
 
+Use --json to output GPU temperatures in JSON format.
+
+Use --once to output temperatures a single time. By default, the program runs in continuous (watch) mode.
+
 If this didn't work, please continue reading
 
 <br>


### PR DESCRIPTION
Hey!
First of all thank you for your project. I run heavy tasks on my 3090 debian server and your work helped me determine that i need some better cooling :)
While an updating table in a terminal is very nice, i prefer having a grafana dashboard with alerts set up. The updating table is hard to parse, so I decided to add --json flag. While at it, I also added --once flag that makes the program output the temperatures once, instead of doing so every REFRESH_DURATION. With those changes I was easily able to write a small python python script that exposes those metrics to prometheus. In case someone else wants to do something similar I decided to contribute my changes. 
Would love to see your thoughts on this merge request!