### PR TITLE
add support for RTX 5060 Ti (0x2d04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ The minimum refresh interval is 50 milliseconds. The default is 1000 millisecond
 Each object contains a timestamp and the selected GPU readings:
 
 ```json
-{"timestamp":1678886400000,"gpus":[{"index":0,"core":55,"junction":68,"vram":72}]}
+{
+  "timestamp": 1678886400000,
+  "gpus": [{ "index": 0, "core": 55, "junction": 68, "vram": 72 }]
+}
 ```
 
 - `timestamp`: Unix timestamp in milliseconds.
@@ -129,7 +132,7 @@ sudo ./gputemps
 
 ## Blackwell support
 
-Experimental junction and GDDR7 VRAM temperature support is included for RTX 5090, RTX 5080, RTX 5070 Ti, and RTX 5070.
+Experimental junction and GDDR7 VRAM temperature support is included for RTX 5090, RTX 5080, RTX 5070 Ti, RTX 5070, and RTX 5060 Ti.
 
 On supported Blackwell GPUs:
 
@@ -138,7 +141,7 @@ On supported Blackwell GPUs:
 
 The same values are available through the JSON `junction` and `vram` properties.
 
-There is no support (yet) for RTX 5060s. Contributions are welcomed.
+There is no support (yet) for RTX 5060. Contributions are welcomed.
 
 ## Troubleshooting
 
@@ -197,6 +200,7 @@ make CPPFLAGS="-I$CUDA_HOME/targets/x86_64-linux/include"
 - RTX 3090
 - RTX 4060 Ti 16GB
 - RTX 4060 Max-Q
+- RTX 5060 Ti
 
 ### Should work
 

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -12,6 +12,7 @@
 #define PCI_DEVICE_ID_RTX_5080 0x2B82u
 #define PCI_DEVICE_ID_RTX_5070_TI 0x2C05u
 #define PCI_DEVICE_ID_RTX_5070 0x2C02u
+#define PCI_DEVICE_ID_RTX_5060_TI 0x2D04u
 
 #define GDDR6_JUNCTION_THERM_OFFSET 0x0002046Cu
 #define GDDR6_VRAM_ADC_OFFSET 0x0000E2A8u
@@ -114,7 +115,8 @@ static const DeviceProfile device_profiles[] = {
     { PCI_DEVICE_ID_RTX_5090, &gddr7_profile },
     { PCI_DEVICE_ID_RTX_5080, &gddr7_profile },
     { PCI_DEVICE_ID_RTX_5070_TI, &gddr7_profile },
-    { PCI_DEVICE_ID_RTX_5070, &gddr7_profile }
+    { PCI_DEVICE_ID_RTX_5070, &gddr7_profile },
+    { PCI_DEVICE_ID_RTX_5060_TI, &gddr7_profile },
 };
 
 static const SensorProfile *select_sensor_profile(uint16_t device_id)


### PR DESCRIPTION
Adds support for the RTX 5060 Ti (GB206 die, PCI Device ID `0x2D04`)

Tested on Linux with kernel parameter `iomem=relaxed` on an NVIDIA GeForce RTX 5060 Ti (`10de:2d04`):
sudo ./gputemps --once

  │ GPU         │  CORE  │  JUNC  │  VRAM  │
0 │ RTX 5060 Ti │  48°C  │  56°C  │  60°C  │